### PR TITLE
add support for --require

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,18 +1,7 @@
 #!/usr/bin/env node
 'use strict'
 
-var path = require('path')
-var pump = require('pump')
-var chart = require('chart-stream')
-var csvWriter = require('csv-write-stream')
-var opn = require('opn')
-var memoryUsage = require('./')
-
-pump(
-  memoryUsage(2000),
-  csvWriter(),
-  chart(opn)
-)
+require('./register.js')
 
 process.argv.splice(1, 1)
 

--- a/register.js
+++ b/register.js
@@ -1,0 +1,16 @@
+'use strict'
+
+// This file can be loaded with --require.
+
+var path = require('path')
+var pump = require('pump')
+var chart = require('chart-stream')
+var csvWriter = require('csv-write-stream')
+var opn = require('opn')
+var memoryUsage = require('./')
+
+pump(
+  memoryUsage(2000),
+  csvWriter(),
+  chart(opn)
+)


### PR DESCRIPTION
Users can now do `node --require memory-usage/register` to inject this
module. This can be useful when customization of the node binary and/or
command line flags may be necessary.