### PR TITLE
Make gc-profiler optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,15 @@
     "chart-stream": "^1.1.0",
     "csv-write-stream": "^2.0.0",
     "from2": "^2.3.0",
-    "gc-profiler": "^1.3.1",
     "opn": "^4.0.2",
     "pump": "^1.0.2"
   },
   "devDependencies": {
     "standard": "^8.5.0",
     "tape": "^4.6.2"
+  },
+  "optionalDependencies": {
+    "gc-profiler": "^1.4.1"
   },
   "scripts": {
     "test": "standard && node test.js"


### PR DESCRIPTION
+ Bump required version to 1.4.1.

Build on Node v12 was fixed in this version.

It's only used when gc option is requested, so if the user doesn't have build env don't fail to install memory-usage.
