### PR TITLE
Use open npm dependency instead of opn

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,13 +5,13 @@ var path = require('path')
 var pump = require('pump')
 var chart = require('chart-stream')
 var csvWriter = require('csv-write-stream')
-var opn = require('opn')
+var open = require('open')
 var memoryUsage = require('./')
 
 pump(
   memoryUsage(2000),
   csvWriter(),
-  chart(opn)
+  chart(open)
 )
 
 process.argv.splice(1, 1)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "csv-write-stream": "^2.0.0",
     "from2": "^2.3.0",
     "gc-profiler": "^1.3.1",
-    "opn": "^4.0.2",
+    "open": "^7.3.0",
     "pump": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
'opn' package has been deprecated and renamed 'open'
Note that opn no longer seems able to spawn xdg-open on linux.